### PR TITLE
Fixes #130 - tomcat shutdown process never recognized as terminated in UI

### DIFF
--- a/.github/workflows/IJ.yml
+++ b/.github/workflows/IJ.yml
@@ -5,25 +5,49 @@ name: Validate against IJ versions
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]    
+    branches: [ main ]
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        IJ: [IC-2019.3, IC-2020.1, IC-2020.2, IC-2020.3, IC-2021.1, IC-2021.2, IC-2021.3]
+        IJ: [IC-2021.1, IC-2021.2, IC-2021.3, IC-2022.1, IC-2022.2, IC-2022.3]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
+        distribution: 'temurin'
+        cache: 'gradle'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build -PideaVersion=${{ matrix.IJ }}
 
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: 'gradle'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew runPluginVerifier -PideaVersion=IC-2022.3
+      - name: Upload report
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: verifier-report
+          path: build/reports/pluginVerifier

--- a/src/main/java/com/redhat/devtools/intellij/rsp/model/impl/SingleRspModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/rsp/model/impl/SingleRspModel.java
@@ -132,8 +132,9 @@ public class SingleRspModel {
         return id;
     }
     public PtyProcess addServerProcess(ServerProcess serverProcess) {
-        RemoteServerProcess sp = new RemoteServerProcess();
-        processes.put(internalIdForProcess(serverProcess), sp);
+        String id = internalIdForProcess(serverProcess);
+        RemoteServerProcess sp = new RemoteServerProcess(id);
+        processes.put(id, sp);
         return sp;
     }
 
@@ -141,7 +142,7 @@ public class SingleRspModel {
         String id = internalIdForProcess(serverProcess);
         RemoteServerProcess sp = processes.get(id);
         if( sp != null ) {
-            sp.terminate();
+            sp.setTerminating();
             processes.remove(id);
         }
     }


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
<!-- Describe the changes here, as detailed as needed. -->
Ensuring the RemoteServerProcess abstraction is guaranteed to be terminated once the rsp client receives the processTerminated event from the backend RSP. 

## Was the change discussed in an issue?
fixes #???
<!-- Please do Link issues here. -->
Fixes #130 

## How to test changes?
<!-- Please describe the steps to test the PR -->
Please see issue #130 